### PR TITLE
Fix case when stocks are also sold. ESPP wasn't detected.

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/StatementModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/StatementModel.cs
@@ -29,7 +29,7 @@ namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 
 		[DeserializeCollectionByRegex(
 			"([0-9]{2}/[0-9]{2} )",
-			"Securities Bought & SoldSettlementDateSecurity NameSymbol/CUSIPDescriptionQuantityPriceTransactionCostAmounti(.+?)Total Securities Bought")]
+			"Securities Bought & SoldSettlementDateSecurity NameSymbol/CUSIPDescriptionQuantityPrice(?:TotalCost Basis)?TransactionCostAmounti(.+?)Total Securities Bought")]
 		public ActivityBuyModel[] ActivityBuy { get; set; }
 	}
 }


### PR DESCRIPTION
Covers the following case if you also sold some stocks when ESPP buy happened.
Without this, it wouldn't be able to detect the section.

![image](https://user-images.githubusercontent.com/282777/111871797-41f60100-898c-11eb-83c1-5823f1c0e152.png)
