### PR TITLE
Fix for Fidelity - handling double or more espp buys

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ActivityBuyModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ActivityBuyModel.cs
@@ -2,7 +2,7 @@
 
 namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 {
-	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}) (?<Name>.+?) ESPP.+You Bought (?<Amount>[0-9]+\\.[0-9]{3})\\$(?<Price>[0-9]+\\.[0-9]{5})")]
+	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}) (?<Name>.+?) ESPP.+You Bought (?<Amount>[0-9]+\\.[0-9]{3})\\$?(?<Price>[0-9]+\\.[0-9]{5})")]
 	internal class ActivityBuyModel
 	{
 		public string Date { get; set; }

--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
@@ -3,7 +3,7 @@ using ASoft.TextDeserializer.Attributes;
 
 namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 {
-	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})")]
+	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$?(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$?(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})")]
 	internal class ESPPModel
 	{
 		public DateTime Date { get; set; }


### PR DESCRIPTION
For some reason if you have more than 1 ESPP buys, it seems Fidelity PDF has one line with dollar sign before the amounts and one without.

<img width="742" alt="espp" src="https://user-images.githubusercontent.com/282777/215438906-ac78ce16-ae71-4290-943f-68cabe624250.png">
<img width="790" alt="buys" src="https://user-images.githubusercontent.com/282777/215438936-0a728ea4-fc21-4635-a900-c2bd59cb7e24.png">
