### PR TITLE
Added chonological sorting for transactions and transaction views

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
@@ -26,11 +26,11 @@ namespace StatementParser.Parsers.Brokers.MorganStanley
 			using var textSource = new TextSource(statementFilePath, true);
 			try
 			{
-				if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
+				if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
 				{
 					return ParseLegacyStatement(textSource);
 				}
-				else if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
+				else if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
 				{
 					return Parse2022Statement(textSource);
 				}

--- a/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
@@ -26,11 +26,11 @@ namespace StatementParser.Parsers.Brokers.MorganStanley
 			using var textSource = new TextSource(statementFilePath, true);
 			try
 			{
-				if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
+				if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
 				{
 					return ParseLegacyStatement(textSource);
 				}
-				else if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
+				else if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
 				{
 					return Parse2022Statement(textSource);
 				}

--- a/StatementParser/StatementParserCLI/Output.cs
+++ b/StatementParser/StatementParserCLI/Output.cs
@@ -13,7 +13,7 @@ namespace StatementParserCLI
 	{
 		private Dictionary<string, List<Transaction>> GroupTransactions(IList<Transaction> transactions)
 		{
-			return transactions.GroupBy(i => i.GetType()).ToDictionary(k => k.Key.Name, i => i.Select(a => a).ToList());
+			return transactions.GroupBy(i => i.GetType()).ToDictionary(k => k.Key.Name, i => i.Select(a => a).OrderBy(t => t.Date).ToList());
 		}
 
 		public void PrintAsJson(IList<Transaction> transactions)

--- a/StatementParser/TaxReporterCLI/Models/Views/DividendBrokerSummaryView.cs
+++ b/StatementParser/TaxReporterCLI/Models/Views/DividendBrokerSummaryView.cs
@@ -6,7 +6,7 @@ using StatementParser.Models;
 
 namespace TaxReporterCLI.Models.Views
 {
-	public class DividendBrokerSummaryView
+    public class DividendBrokerSummaryView : IView
 	{
 		[Description("Exchanged to currency")]
 		public Currency ExchangedToCurrency { get; }
@@ -74,5 +74,10 @@ namespace TaxReporterCLI.Models.Views
 		{
 			return $"{nameof(ExchangedToCurrency)}: {ExchangedToCurrency} {nameof(Broker)}: {Broker} {nameof(Currency)}: {Currency} {nameof(TotalIncome)}: {TotalIncome} {nameof(TotalTax)}: {TotalTax} {nameof(ExchangedPerDayTotalIncome)}: {ExchangedPerDayTotalIncome} {nameof(ExchangedPerYearTotalIncome)}: {ExchangedPerYearTotalIncome} {nameof(ExchangedPerDayTotalTax)}: {ExchangedPerDayTotalTax} {nameof(ExchangedPerYearTotalTax)}: {ExchangedPerYearTotalTax}";
 		}
-	}
+
+        public int CompareTo(IView other)
+        {
+            return 0;
+        }
+    }
 }

--- a/StatementParser/TaxReporterCLI/Models/Views/DividendCurrencySummaryView.cs
+++ b/StatementParser/TaxReporterCLI/Models/Views/DividendCurrencySummaryView.cs
@@ -6,7 +6,7 @@ using StatementParser.Models;
 
 namespace TaxReporterCLI.Models.Views
 {
-	public class DividendCurrencySummaryView
+	public class DividendCurrencySummaryView : IView
 	{
 		[Description("Exchanged to currency")]
 		public Currency ExchangedToCurrency { get; }
@@ -71,5 +71,10 @@ namespace TaxReporterCLI.Models.Views
 		{
 			return $"{nameof(ExchangedToCurrency)}: {ExchangedToCurrency} {nameof(Currency)}: {Currency} {nameof(TotalIncome)}: {TotalIncome} {nameof(TotalTax)}: {TotalTax} {nameof(ExchangedPerDayTotalIncome)}: {ExchangedPerDayTotalIncome} {nameof(ExchangedPerYearTotalIncome)}: {ExchangedPerYearTotalIncome} {nameof(ExchangedPerDayTotalTax)}: {ExchangedPerDayTotalTax} {nameof(ExchangedPerYearTotalTax)}: {ExchangedPerYearTotalTax}";
 		}
-	}
+
+        public int CompareTo(IView other)
+        {
+            return 0;
+        }
+    }
 }

--- a/StatementParser/TaxReporterCLI/Models/Views/IView.cs
+++ b/StatementParser/TaxReporterCLI/Models/Views/IView.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace TaxReporterCLI.Models.Views
+{
+    public interface IView : IComparable<IView>
+    {
+    }
+}

--- a/StatementParser/TaxReporterCLI/Models/Views/TransactionView.cs
+++ b/StatementParser/TaxReporterCLI/Models/Views/TransactionView.cs
@@ -1,9 +1,10 @@
+using System;
 using StatementParser.Attributes;
 using StatementParser.Models;
 
 namespace TaxReporterCLI.Models.Views
 {
-	public class TransactionView
+	public class TransactionView : IView
 	{
 		public Transaction Transaction { get; }
 
@@ -28,5 +29,14 @@ namespace TaxReporterCLI.Models.Views
 		{
 			return $"{Transaction} {nameof(ExchangedToCurrency)}:{ExchangedToCurrency} {nameof(ExchangeRatePerDay)}: {ExchangeRatePerDay} {nameof(ExchangeRatePerYear)}: {ExchangeRatePerYear}";
 		}
-	}
+
+        public int CompareTo(IView other)
+        {
+			if(!(other is TransactionView))
+			{
+				return 0;
+			}
+            return this.Transaction.Date.CompareTo((other as TransactionView).Transaction.Date);
+        }
+    }
 }

--- a/StatementParser/TaxReporterCLI/Output.cs
+++ b/StatementParser/TaxReporterCLI/Output.cs
@@ -7,31 +7,32 @@ using Newtonsoft.Json;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using StatementParser.Attributes;
+using TaxReporterCLI.Models.Views;
 
 namespace TaxReporterCLI
 {
 	internal class Output
 	{
-		private Dictionary<string, List<object>> GroupTransactions(IList<object> transactions)
+		private Dictionary<string, List<IView>> GroupViews(IList<IView> views)
 		{
-			return transactions.GroupBy(i => i.GetType()).ToDictionary(k => k.Key.Name, i => i.Select(a => a).ToList());
+			return views.GroupBy(i => i.GetType()).ToDictionary(k => k.Key.Name, i => i.Select(a => a).OrderBy(x => x).ToList());
 		}
 
-		public void PrintAsJson(IList<object> transactions)
+		public void PrintAsJson(IList<IView> views)
 		{
-			var groupedTransactions = GroupTransactions(transactions);
+			var groupedTransactions = GroupViews(views);
 
 			Console.WriteLine(JsonConvert.SerializeObject(groupedTransactions));
 		}
 
-		public void SaveAsExcelSheet(string filePath, IList<object> transactions)
+		public void SaveAsExcelSheet(string filePath, IList<IView> views)
 		{
-			var groupedTransactions = GroupTransactions(transactions);
+			var groupedViews = GroupViews(views);
 
             using FileStream file = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite);
             var wb1 = new XSSFWorkbook();
 
-            foreach (var group in groupedTransactions)
+            foreach (var group in groupedViews)
             {
                 wb1.Add(CreateSheet(wb1, @group.Key, @group.Value));
             }
@@ -39,11 +40,11 @@ namespace TaxReporterCLI
             wb1.Write(file);
         }
 
-		public void PrintAsPlainText(IList<object> transactions)
+		public void PrintAsPlainText(IList<IView> views)
 		{
-			var groupedTransactions = GroupTransactions(transactions);
+			var groupedViews = GroupViews(views);
 
-			foreach (var group in groupedTransactions)
+			foreach (var group in groupedViews)
 			{
 				Console.WriteLine();
 				Console.WriteLine(group.Key);
@@ -51,7 +52,7 @@ namespace TaxReporterCLI
 			}
 		}
 
-		private ISheet CreateSheet(XSSFWorkbook workbook, string sheetName, IList<object> objects)
+		private ISheet CreateSheet(XSSFWorkbook workbook, string sheetName, IList<IView> objects)
 		{
 			var sheet = workbook.CreateSheet(sheetName);
 

--- a/StatementParser/TaxReporterCLI/Program.cs
+++ b/StatementParser/TaxReporterCLI/Program.cs
@@ -83,15 +83,15 @@ namespace TaxReporterCLI
 
             var summaryViews = CreateDividendSummaryViews(transactionViews);
 
-            var views = new List<object>(transactionViews);
+            var views = new List<IView>(transactionViews);
             views.AddRange(summaryViews);
 
             Print(option, views);
         }
 
-        private static IList<object> CreateDividendSummaryViews(IList<TransactionView> transactionViews)
+        private static IList<IView> CreateDividendSummaryViews(IList<TransactionView> transactionViews)
         {
-            var summaryViews = new List<object>();
+            var summaryViews = new List<IView>();
 
             var usedBrokers = transactionViews.Select(i => i.Transaction.Broker).Distinct();
             var usedCurrencies = transactionViews.Select(i => i.Transaction.Currency).Distinct();
@@ -119,7 +119,7 @@ namespace TaxReporterCLI
             return summaryViews;
         }
 
-        private static void Print(Options option, IList<object> views)
+        private static void Print(Options option, IList<IView> views)
 		{
 			var printer = new Output();
 			if (option.ShouldPrintAsJson)


### PR DESCRIPTION
The order was not guaranteed which is a little inconvenient to track the changes visually. Added explicit sorting for transactions and transaction views.
As a side effect added a bit of strong typing to TaxReporter and marker interface for the views

Before 

> DepositTransactionView
> Broker: XXXX Date: 15.06.2023 Name: XXXX
> Broker: XXXX Date: 30.06.2023 Name: XXXX
> Broker: XXXX Date: 15.01.2023 Name: XXXX
> Broker: XXXX Date: 28.01.2023 Name: XXXX


After 

> DepositTransactionView
> Broker: XXXX Date: 15.01.2023 Name: XXXX
> Broker: XXXX Date: 28.01.2023 Name: XXXX
> Broker: XXXX Date: 15.06.2023 Name: XXXX
> Broker: XXXX Date: 30.06.2023 Name: XXXX
> 