### PR TITLE
Checking if PDF has a title for Morgan Stanley parser

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
@@ -26,11 +26,11 @@ namespace StatementParser.Parsers.Brokers.MorganStanley
 			using var textSource = new TextSource(statementFilePath, true);
 			try
 			{
-				if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
+				if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
 				{
 					return ParseLegacyStatement(textSource);
 				}
-				else if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
+				else if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
 				{
 					return Parse2022Statement(textSource);
 				}


### PR DESCRIPTION
Looks like this PR https://github.com/vladimir-aubrecht/StatementParser/pull/20 by @yirkha  made the parser fail on PDFs which don't have title (i.e. Fidelity statements).

Added a null pointer check