### PR TITLE
Added sortable date format for excel output

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/MorganStanley/MorganStanleyStatementPdfParser.cs
@@ -26,11 +26,11 @@ namespace StatementParser.Parsers.Brokers.MorganStanley
 			using var textSource = new TextSource(statementFilePath, true);
 			try
 			{
-				if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
+				if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document SP10 History Statements "))
 				{
 					return ParseLegacyStatement(textSource);
 				}
-				else if (Regex.IsMatch(textSource.Title, @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
+				else if (Regex.IsMatch(textSource.Title ?? "", @"^Morgan Stanley Smith Barney Document EPS217CCC linux-TTF New$"))
 				{
 					return Parse2022Statement(textSource);
 				}

--- a/StatementParser/TaxReporterCLI/Output.cs
+++ b/StatementParser/TaxReporterCLI/Output.cs
@@ -82,6 +82,11 @@ namespace TaxReporterCLI
 				{
 					cell.SetCellValue((double)value);
 				}
+				//For dates using the sortable format so excel can treat it better or at least sort as a string
+				else if(DateTime.TryParse(rowValue, out var dateValue))
+				{
+					cell.SetCellValue(dateValue.ToString("s"));
+				}
 				else
 				{
 					cell.SetCellValue(rowValue);


### PR DESCRIPTION
> What do men and Excel have in common?
> They both wrongly assume something is a date when it’s not.


On a serious note - date is now output in a current machine locale and it messes up excel/google sheets.
Added formatting of the date in a sortable form to give excel better chance to process it or at least make the dates sortable as strings

Before:
<img width="170" alt="image" src="https://github.com/vladimir-aubrecht/StatementParser/assets/546728/c47efb0b-dfc7-4ddb-af2b-1ed1a996771a">

After:
<img width="213" alt="image" src="https://github.com/vladimir-aubrecht/StatementParser/assets/546728/0e7dddfb-b092-44f1-96a1-dd1df09e8a4e">
