### PR TITLE
Sortable dates for XLSX outputs

### DIFF
--- a/StatementParser/StatementParserCLI/Output.cs
+++ b/StatementParser/StatementParserCLI/Output.cs
@@ -70,7 +70,14 @@ namespace StatementParserCLI
 			{
 				var cell = row.CreateCell(columnIndex);
 
-				cell.SetCellValue(rowValue);
+				if(DateTime.TryParse(rowValue, out var dateValue))
+				{
+					cell.SetCellValue(dateValue.ToString("s"));
+				}
+				else
+				{
+					cell.SetCellValue(rowValue);
+				}
 
 				columnIndex++;
 			}

--- a/StatementParser/TaxReporterCLI/Output.cs
+++ b/StatementParser/TaxReporterCLI/Output.cs
@@ -82,6 +82,11 @@ namespace TaxReporterCLI
 				{
 					cell.SetCellValue((double)value);
 				}
+				//For dates using the sortable format so excel can treat it better or at least sort as a string
+				else if(DateTime.TryParse(rowValue, out var dateValue))
+				{
+					cell.SetCellValue(dateValue.ToString("s"));
+				}
 				else
 				{
 					cell.SetCellValue(rowValue);


### PR DESCRIPTION
> What do men and Excel have in common?
> They both wrongly assume something is a date when it’s not.


On a serious note - date is now output in a current machine locale and it messes up excel/google sheets.
Added formatting of the date in a sortable form to give excel better chance to process it or at least make the dates sortable as strings

Before:
<img width="170" alt="image" src="https://github.com/vladimir-aubrecht/StatementParser/assets/546728/c47efb0b-dfc7-4ddb-af2b-1ed1a996771a">

After:
<img width="213" alt="image" src="https://github.com/vladimir-aubrecht/StatementParser/assets/546728/0e7dddfb-b092-44f1-96a1-dd1df09e8a4e">
