### PR TITLE
Added possibility to override yearly exchange rates from command line

### DIFF
--- a/StatementParser/ExchangeRateProvider/ExchangeRateProvider.csproj
+++ b/StatementParser/ExchangeRateProvider/ExchangeRateProvider.csproj
@@ -4,8 +4,6 @@
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <Folder Include="Providers\" />
-        <Folder Include="Providers\Czk\" />
         <Folder Include="Models\" />
     </ItemGroup>
     <ItemGroup>

--- a/StatementParser/ExchangeRateProvider/Providers/Czk/StaticExchangeRateProvider.cs
+++ b/StatementParser/ExchangeRateProvider/Providers/Czk/StaticExchangeRateProvider.cs
@@ -1,0 +1,31 @@
+﻿using ExchangeRateProvider.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeRateProvider.Providers.Czk
+{
+    public class StaticExchangeRateProvider : IExchangeProvider
+    {
+        private readonly IDictionary<string, decimal> currencyToPriceDictionary;
+
+        public StaticExchangeRateProvider(IDictionary<string, decimal> currencyToPriceDictionary)
+        {
+            this.currencyToPriceDictionary = currencyToPriceDictionary;
+        }
+
+        public Task<ICurrencyList> FetchCurrencyListByDateAsync(DateTime date)
+        {
+            var currencyList = new List<CurrencyDescriptor>();
+
+            foreach (var currencyToPrice in currencyToPriceDictionary)
+            {
+                currencyList.Add(new CurrencyDescriptor(currencyToPrice.Key, "N/A", currencyToPrice.Value, "N/A"));
+            }
+
+            return Task.FromResult(new CurrencyList(currencyList) as ICurrencyList);
+        }
+    }
+}

--- a/StatementParser/TaxReporterCLI/Options.cs
+++ b/StatementParser/TaxReporterCLI/Options.cs
@@ -10,6 +10,9 @@ namespace TaxReporterCLI
         [Parameter("x", "excelSheetPath", Required = Required.No, Description = "Absolute or relative path to file where excel sheet will be stored.")]
         public string ExcelSheetPath { get; set; } = null;
 
+        [Parameter("r", "overrideYearlyExchangeRate", Required = Required.No, Description = "Yearly exchange rate which should be used instead of downloaded one. This is override useful in case yearly exchange rate is not published to proper place yet. Use json format: {'usd' = 23.0, 'czk' = 0.5}.")]
+        public string OverrideYearlyExchangeRate { get; set; } = null;
+
         [PositionalParameter(0, "inputStatementFilePath", Required = Required.Yes, Description = "Relative or absolute path to statement file or multiple paths each as one argument.")]
         [PositionalParameterList]
         public string[] StatementFilePaths { get; set; }


### PR DESCRIPTION
Added possibility to override yearly exchange rates from command line.

Use parameter -r or --overrideYearlyExchangeRate to specify yearly exchange rates which should be used instead of downloaded one. Format is json: {'usd' = 23.0, 'czk' = 0.5}