### PR TITLE
Fix Fidelity dividend regex to support alphanumeric CUSIP identifiers

### DIFF
--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ActivityDividendModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ActivityDividendModel.cs
@@ -2,7 +2,7 @@
 
 namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 {
-	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}) (?<Name>.+?)  ?[0-9]+ Dividend Received  --\\$?(?<Income>[0-9]+\\.[0-9]{2})")]
+	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}) (?<Name>.+?)  ?[0-9A-Za-z]+ Dividend Received  --\\$?(?<Income>[0-9]+\\.[0-9]{2})")]
 	internal class ActivityDividendModel
 	{
 		public string Date { get; set; }


### PR DESCRIPTION
## Summary
- The CUSIP identifier before "Dividend Received" can contain letters (e.g., `31617H821` for money market funds)
- Changed regex from `[0-9]+` to `[0-9A-Za-z]+` so these dividends are correctly parsed
- Previously, only dividends with purely numeric CUSIPs (like Microsoft's `594918104`) were captured, while money market fund dividends with alphanumeric CUSIPs were silently skipped

## Test plan
- [ ] Verify Fidelity statements with alphanumeric CUSIPs (e.g., money market funds) are parsed correctly
- [ ] Verify Fidelity statements with numeric-only CUSIPs (e.g., MSFT) still parse correctly
- [ ] Verify no duplicate dividends are produced from a single statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)