### PR TITLE
feat: add Tax Summary sheet and multi-year transaction filter

### DIFF
--- a/StatementParser/TaxReporterCLI/ExcelHelper.cs
+++ b/StatementParser/TaxReporterCLI/ExcelHelper.cs
@@ -1,0 +1,38 @@
+using NPOI.SS.UserModel;
+
+namespace TaxReporterCLI
+{
+	internal static class ExcelHelper
+	{
+		public static string GetExcelColumnLetter(int columnIndex)
+		{
+			var result = "";
+			while (columnIndex >= 0)
+			{
+				result = (char)('A' + columnIndex % 26) + result;
+				columnIndex = columnIndex / 26 - 1;
+			}
+			return result;
+		}
+
+		public static int FindColumnIndex(ISheet sheet, string startsWith, string endsWith)
+		{
+			var headerRow = sheet.GetRow(0);
+			if (headerRow == null) return -1;
+
+			for (int i = 0; i < headerRow.LastCellNum; i++)
+			{
+				var cell = headerRow.GetCell(i);
+				if (cell == null) continue;
+
+				var value = cell.StringCellValue;
+				if (value != null && value.StartsWith(startsWith) && value.EndsWith(endsWith))
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+	}
+}

--- a/StatementParser/TaxReporterCLI/ExcelHelper.cs
+++ b/StatementParser/TaxReporterCLI/ExcelHelper.cs
@@ -23,7 +23,7 @@ namespace TaxReporterCLI
 			for (int i = 0; i < headerRow.LastCellNum; i++)
 			{
 				var cell = headerRow.GetCell(i);
-				if (cell == null) continue;
+				if (cell == null || cell.CellType != CellType.String) continue;
 
 				var value = cell.StringCellValue;
 				if (value != null && value.StartsWith(startsWith) && value.EndsWith(endsWith))

--- a/StatementParser/TaxReporterCLI/Output.cs
+++ b/StatementParser/TaxReporterCLI/Output.cs
@@ -32,10 +32,16 @@ namespace TaxReporterCLI
             using FileStream file = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite);
             var wb1 = new XSSFWorkbook();
 
+            var sheetMeta = new Dictionary<string, (ISheet Sheet, int DataRowCount)>();
+
             foreach (var group in groupedViews)
             {
-                wb1.Add(CreateSheet(wb1, @group.Key, @group.Value));
+                var sheet = CreateSheet(wb1, @group.Key, @group.Value);
+                wb1.Add(sheet);
+                sheetMeta[@group.Key] = (sheet, @group.Value.Count);
             }
+
+            wb1.Add(CreateTaxSummarySheet(wb1, sheetMeta));
 
             wb1.Write(file);
         }
@@ -97,6 +103,144 @@ namespace TaxReporterCLI
 			}
 
 			return row;
+		}
+
+		private ISheet CreateTaxSummarySheet(XSSFWorkbook workbook, Dictionary<string, (ISheet Sheet, int DataRowCount)> sheetMeta)
+		{
+			var summarySheet = workbook.CreateSheet("Tax Summary");
+
+			// CZK currency format
+			var czkFormat = workbook.CreateDataFormat().GetFormat("#,##0.00 \"Kč\"");
+			var czkStyle = workbook.CreateCellStyle();
+			czkStyle.DataFormat = czkFormat;
+
+			// Row 0: Header
+			var headerRow = summarySheet.CreateRow(0);
+			headerRow.CreateCell(0).SetCellValue("Section");
+			headerRow.CreateCell(1).SetCellValue("Daily Rate (CZK)");
+			headerRow.CreateCell(2).SetCellValue("Yearly Rate (CZK)");
+
+			// Define sections: (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix)
+			var sections = new[]
+			{
+				("Dividends - Income", "DividendTransactionView", "Income", "per Day", "Income", "per Year"),
+				("Sales - Profit", "SaleTransactionView", "Profit", "per Day", "Profit", "per Year"),
+				("ESPP - Profit", "ESPPTransactionView", "Total Profit", "per Day", "Total Profit", "per Year"),
+				("Deposits - Price", "DepositTransactionView", "Total Price", "per Day", "Total Price", "per Year"),
+			};
+
+			int summaryRowIndex = 1;
+			foreach (var (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix) in sections)
+			{
+				var row = summarySheet.CreateRow(summaryRowIndex);
+				row.CreateCell(0).SetCellValue(label);
+
+				if (sheetMeta.TryGetValue(sheetName, out var meta) && meta.DataRowCount > 0)
+				{
+					WriteSumFormulaCell(row, 1, meta.Sheet, meta.DataRowCount, dailyPrefix, dailySuffix, czkStyle);
+					WriteSumFormulaCell(row, 2, meta.Sheet, meta.DataRowCount, yearlyPrefix, yearlySuffix, czkStyle);
+				}
+				else
+				{
+					var dailyCell = row.CreateCell(1);
+					dailyCell.SetCellValue(0);
+					dailyCell.CellStyle = czkStyle;
+					var yearlyCell = row.CreateCell(2);
+					yearlyCell.SetCellValue(0);
+					yearlyCell.CellStyle = czkStyle;
+				}
+
+				summaryRowIndex++;
+			}
+
+			// Total row (SUM of the 4 section rows above)
+			var totalRow = summarySheet.CreateRow(summaryRowIndex);
+			totalRow.CreateCell(0).SetCellValue("Total");
+			var totalDailyCell = totalRow.CreateCell(1);
+			totalDailyCell.SetCellFormula("SUM(B2:B5)");
+			totalDailyCell.CellStyle = czkStyle;
+			var totalYearlyCell = totalRow.CreateCell(2);
+			totalYearlyCell.SetCellFormula("SUM(C2:C5)");
+			totalYearlyCell.CellStyle = czkStyle;
+			summaryRowIndex++;
+
+			// Empty row
+			summaryRowIndex++;
+
+			// Dividends - Tax withheld (separate from total)
+			var taxRow = summarySheet.CreateRow(summaryRowIndex);
+			taxRow.CreateCell(0).SetCellValue("Dividends - Tax withheld");
+
+			if (sheetMeta.TryGetValue("DividendTransactionView", out var divMeta) && divMeta.DataRowCount > 0)
+			{
+				WriteSumFormulaCell(taxRow, 1, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Day", czkStyle);
+				WriteSumFormulaCell(taxRow, 2, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Year", czkStyle);
+			}
+			else
+			{
+				var dailyCell = taxRow.CreateCell(1);
+				dailyCell.SetCellValue(0);
+				dailyCell.CellStyle = czkStyle;
+				var yearlyCell = taxRow.CreateCell(2);
+				yearlyCell.SetCellValue(0);
+				yearlyCell.CellStyle = czkStyle;
+			}
+
+			// Auto-size columns
+			for (int col = 0; col <= 2; col++)
+			{
+				summarySheet.AutoSizeColumn(col);
+			}
+
+			return summarySheet;
+		}
+
+		private void WriteSumFormulaCell(IRow row, int cellIndex, ISheet sourceSheet, int dataRowCount, string headerPrefix, string headerSuffix, ICellStyle style)
+		{
+			var colIndex = FindColumnIndex(sourceSheet, headerPrefix, headerSuffix);
+			var cell = row.CreateCell(cellIndex);
+			cell.CellStyle = style;
+			if (colIndex >= 0)
+			{
+				var colLetter = GetExcelColumnLetter(colIndex);
+				var formula = $"SUM({sourceSheet.SheetName}!{colLetter}2:{colLetter}{dataRowCount + 1})";
+				cell.SetCellFormula(formula);
+			}
+			else
+			{
+				cell.SetCellValue(0);
+			}
+		}
+
+		private static int FindColumnIndex(ISheet sheet, string startsWith, string endsWith)
+		{
+			var headerRow = sheet.GetRow(0);
+			if (headerRow == null) return -1;
+
+			for (int i = 0; i < headerRow.LastCellNum; i++)
+			{
+				var cell = headerRow.GetCell(i);
+				if (cell == null) continue;
+
+				var value = cell.StringCellValue;
+				if (value != null && value.StartsWith(startsWith) && value.EndsWith(endsWith))
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		private static string GetExcelColumnLetter(int columnIndex)
+		{
+			var result = "";
+			while (columnIndex >= 0)
+			{
+				result = (char)('A' + columnIndex % 26) + result;
+				columnIndex = columnIndex / 26 - 1;
+			}
+			return result;
 		}
 
 		private IDictionary<PropertyInfo, string> CollectPublicProperties(Object instance)

--- a/StatementParser/TaxReporterCLI/Output.cs
+++ b/StatementParser/TaxReporterCLI/Output.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -41,7 +41,8 @@ namespace TaxReporterCLI
                 sheetMeta[@group.Key] = (sheet, @group.Value.Count);
             }
 
-            wb1.Add(CreateTaxSummarySheet(wb1, sheetMeta));
+            var summaryBuilder = new TaxSummarySheetBuilder();
+            wb1.Add(summaryBuilder.Build(wb1, sheetMeta));
 
             wb1.Write(file);
         }
@@ -103,144 +104,6 @@ namespace TaxReporterCLI
 			}
 
 			return row;
-		}
-
-		private ISheet CreateTaxSummarySheet(XSSFWorkbook workbook, Dictionary<string, (ISheet Sheet, int DataRowCount)> sheetMeta)
-		{
-			var summarySheet = workbook.CreateSheet("Tax Summary");
-
-			// CZK currency format
-			var czkFormat = workbook.CreateDataFormat().GetFormat("#,##0.00 \"Kč\"");
-			var czkStyle = workbook.CreateCellStyle();
-			czkStyle.DataFormat = czkFormat;
-
-			// Row 0: Header
-			var headerRow = summarySheet.CreateRow(0);
-			headerRow.CreateCell(0).SetCellValue("Section");
-			headerRow.CreateCell(1).SetCellValue("Daily Rate (CZK)");
-			headerRow.CreateCell(2).SetCellValue("Yearly Rate (CZK)");
-
-			// Define sections: (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix)
-			var sections = new[]
-			{
-				("Dividends - Income", "DividendTransactionView", "Income", "per Day", "Income", "per Year"),
-				("Sales - Profit", "SaleTransactionView", "Profit", "per Day", "Profit", "per Year"),
-				("ESPP - Profit", "ESPPTransactionView", "Total Profit", "per Day", "Total Profit", "per Year"),
-				("Deposits - Price", "DepositTransactionView", "Total Price", "per Day", "Total Price", "per Year"),
-			};
-
-			int summaryRowIndex = 1;
-			foreach (var (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix) in sections)
-			{
-				var row = summarySheet.CreateRow(summaryRowIndex);
-				row.CreateCell(0).SetCellValue(label);
-
-				if (sheetMeta.TryGetValue(sheetName, out var meta) && meta.DataRowCount > 0)
-				{
-					WriteSumFormulaCell(row, 1, meta.Sheet, meta.DataRowCount, dailyPrefix, dailySuffix, czkStyle);
-					WriteSumFormulaCell(row, 2, meta.Sheet, meta.DataRowCount, yearlyPrefix, yearlySuffix, czkStyle);
-				}
-				else
-				{
-					var dailyCell = row.CreateCell(1);
-					dailyCell.SetCellValue(0);
-					dailyCell.CellStyle = czkStyle;
-					var yearlyCell = row.CreateCell(2);
-					yearlyCell.SetCellValue(0);
-					yearlyCell.CellStyle = czkStyle;
-				}
-
-				summaryRowIndex++;
-			}
-
-			// Total row (SUM of the 4 section rows above)
-			var totalRow = summarySheet.CreateRow(summaryRowIndex);
-			totalRow.CreateCell(0).SetCellValue("Total");
-			var totalDailyCell = totalRow.CreateCell(1);
-			totalDailyCell.SetCellFormula("SUM(B2:B5)");
-			totalDailyCell.CellStyle = czkStyle;
-			var totalYearlyCell = totalRow.CreateCell(2);
-			totalYearlyCell.SetCellFormula("SUM(C2:C5)");
-			totalYearlyCell.CellStyle = czkStyle;
-			summaryRowIndex++;
-
-			// Empty row
-			summaryRowIndex++;
-
-			// Dividends - Tax withheld (separate from total)
-			var taxRow = summarySheet.CreateRow(summaryRowIndex);
-			taxRow.CreateCell(0).SetCellValue("Dividends - Tax withheld");
-
-			if (sheetMeta.TryGetValue("DividendTransactionView", out var divMeta) && divMeta.DataRowCount > 0)
-			{
-				WriteSumFormulaCell(taxRow, 1, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Day", czkStyle);
-				WriteSumFormulaCell(taxRow, 2, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Year", czkStyle);
-			}
-			else
-			{
-				var dailyCell = taxRow.CreateCell(1);
-				dailyCell.SetCellValue(0);
-				dailyCell.CellStyle = czkStyle;
-				var yearlyCell = taxRow.CreateCell(2);
-				yearlyCell.SetCellValue(0);
-				yearlyCell.CellStyle = czkStyle;
-			}
-
-			// Auto-size columns
-			for (int col = 0; col <= 2; col++)
-			{
-				summarySheet.AutoSizeColumn(col);
-			}
-
-			return summarySheet;
-		}
-
-		private void WriteSumFormulaCell(IRow row, int cellIndex, ISheet sourceSheet, int dataRowCount, string headerPrefix, string headerSuffix, ICellStyle style)
-		{
-			var colIndex = FindColumnIndex(sourceSheet, headerPrefix, headerSuffix);
-			var cell = row.CreateCell(cellIndex);
-			cell.CellStyle = style;
-			if (colIndex >= 0)
-			{
-				var colLetter = GetExcelColumnLetter(colIndex);
-				var formula = $"SUM({sourceSheet.SheetName}!{colLetter}2:{colLetter}{dataRowCount + 1})";
-				cell.SetCellFormula(formula);
-			}
-			else
-			{
-				cell.SetCellValue(0);
-			}
-		}
-
-		private static int FindColumnIndex(ISheet sheet, string startsWith, string endsWith)
-		{
-			var headerRow = sheet.GetRow(0);
-			if (headerRow == null) return -1;
-
-			for (int i = 0; i < headerRow.LastCellNum; i++)
-			{
-				var cell = headerRow.GetCell(i);
-				if (cell == null) continue;
-
-				var value = cell.StringCellValue;
-				if (value != null && value.StartsWith(startsWith) && value.EndsWith(endsWith))
-				{
-					return i;
-				}
-			}
-
-			return -1;
-		}
-
-		private static string GetExcelColumnLetter(int columnIndex)
-		{
-			var result = "";
-			while (columnIndex >= 0)
-			{
-				result = (char)('A' + columnIndex % 26) + result;
-				columnIndex = columnIndex / 26 - 1;
-			}
-			return result;
 		}
 
 		private IDictionary<PropertyInfo, string> CollectPublicProperties(Object instance)

--- a/StatementParser/TaxReporterCLI/Program.cs
+++ b/StatementParser/TaxReporterCLI/Program.cs
@@ -84,6 +84,14 @@ namespace TaxReporterCLI
                 }
             }
 
+            transactions = FilterTransactionsByYear(transactions);
+
+            if (transactions.Count == 0)
+            {
+                Console.WriteLine("No transactions to process.");
+                return;
+            }
+
             Console.WriteLine("Downloading exchange rates ...");
 
             var builder = new TransactionViewBuilder(yearlyExchangeRateProvider, cnbProvider);
@@ -95,6 +103,51 @@ namespace TaxReporterCLI
             views.AddRange(summaryViews);
 
             Print(option, views);
+        }
+
+        private static List<Transaction> FilterTransactionsByYear(List<Transaction> transactions)
+        {
+            var years = transactions.Select(t => t.Date.Year).Distinct().OrderBy(y => y).ToList();
+
+            if (years.Count <= 1)
+            {
+                return transactions;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Warning: Transactions span multiple years: {string.Join(", ", years)}");
+            Console.WriteLine("Tax reports are typically filed per year. Please choose:");
+            Console.WriteLine();
+
+            for (int i = 0; i < years.Count; i++)
+            {
+                var count = transactions.Count(t => t.Date.Year == years[i]);
+                Console.WriteLine($"  {i + 1}) {years[i]} only ({count} transactions)");
+            }
+            Console.WriteLine($"  {years.Count + 1}) All years combined");
+            Console.WriteLine();
+
+            while (true)
+            {
+                Console.Write($"Enter choice (1-{years.Count + 1}): ");
+                var input = Console.ReadLine();
+
+                if (int.TryParse(input, out var choice) && choice >= 1 && choice <= years.Count + 1)
+                {
+                    if (choice == years.Count + 1)
+                    {
+                        Console.WriteLine("Proceeding with all transactions.");
+                        return transactions;
+                    }
+
+                    var selectedYear = years[choice - 1];
+                    var filtered = transactions.Where(t => t.Date.Year == selectedYear).ToList();
+                    Console.WriteLine($"Proceeding with {filtered.Count} transactions from {selectedYear}.");
+                    return filtered;
+                }
+
+                Console.WriteLine("Invalid choice. Please try again.");
+            }
         }
 
         private static IList<IView> CreateDividendSummaryViews(IList<TransactionView> transactionViews)

--- a/StatementParser/TaxReporterCLI/Program.cs
+++ b/StatementParser/TaxReporterCLI/Program.cs
@@ -132,6 +132,12 @@ namespace TaxReporterCLI
                 Console.Write($"Enter choice (1-{years.Count + 1}): ");
                 var input = Console.ReadLine();
 
+                if (input == null)
+                {
+                    Console.WriteLine("No input available. Proceeding with all transactions.");
+                    return transactions;
+                }
+
                 if (int.TryParse(input, out var choice) && choice >= 1 && choice <= years.Count + 1)
                 {
                     if (choice == years.Count + 1)

--- a/StatementParser/TaxReporterCLI/TaxSummarySheetBuilder.cs
+++ b/StatementParser/TaxReporterCLI/TaxSummarySheetBuilder.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+
+namespace TaxReporterCLI
+{
+	internal class TaxSummarySheetBuilder
+	{
+		public ISheet Build(XSSFWorkbook workbook, Dictionary<string, (ISheet Sheet, int DataRowCount)> sheetMeta)
+		{
+			var summarySheet = workbook.CreateSheet("Tax Summary");
+
+			// CZK currency format
+			var czkFormat = workbook.CreateDataFormat().GetFormat("#,##0.00 \"Kč\"");
+			var czkStyle = workbook.CreateCellStyle();
+			czkStyle.DataFormat = czkFormat;
+
+			// Row 0: Header
+			var headerRow = summarySheet.CreateRow(0);
+			headerRow.CreateCell(0).SetCellValue("Section");
+			headerRow.CreateCell(1).SetCellValue("Daily Rate (CZK)");
+			headerRow.CreateCell(2).SetCellValue("Yearly Rate (CZK)");
+
+			// Define sections: (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix)
+			var sections = new[]
+			{
+				("Dividends - Income", "DividendTransactionView", "Income", "per Day", "Income", "per Year"),
+				("Sales - Profit", "SaleTransactionView", "Profit", "per Day", "Profit", "per Year"),
+				("ESPP - Profit", "ESPPTransactionView", "Total Profit", "per Day", "Total Profit", "per Year"),
+				("Deposits - Price", "DepositTransactionView", "Total Price", "per Day", "Total Price", "per Year"),
+			};
+
+			int summaryRowIndex = 1;
+			foreach (var (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix) in sections)
+			{
+				var row = summarySheet.CreateRow(summaryRowIndex);
+				row.CreateCell(0).SetCellValue(label);
+
+				if (sheetMeta.TryGetValue(sheetName, out var meta) && meta.DataRowCount > 0)
+				{
+					WriteSumFormulaCell(row, 1, meta.Sheet, meta.DataRowCount, dailyPrefix, dailySuffix, czkStyle);
+					WriteSumFormulaCell(row, 2, meta.Sheet, meta.DataRowCount, yearlyPrefix, yearlySuffix, czkStyle);
+				}
+				else
+				{
+					CreateZeroCell(row, 1, czkStyle);
+					CreateZeroCell(row, 2, czkStyle);
+				}
+
+				summaryRowIndex++;
+			}
+
+			// Total row (SUM of the 4 section rows above)
+			var totalRow = summarySheet.CreateRow(summaryRowIndex);
+			totalRow.CreateCell(0).SetCellValue("Total");
+			var totalDailyCell = totalRow.CreateCell(1);
+			totalDailyCell.SetCellFormula("SUM(B2:B5)");
+			totalDailyCell.CellStyle = czkStyle;
+			var totalYearlyCell = totalRow.CreateCell(2);
+			totalYearlyCell.SetCellFormula("SUM(C2:C5)");
+			totalYearlyCell.CellStyle = czkStyle;
+			summaryRowIndex++;
+
+			// Empty row
+			summaryRowIndex++;
+
+			// Dividends - Tax withheld (separate from total)
+			var taxRow = summarySheet.CreateRow(summaryRowIndex);
+			taxRow.CreateCell(0).SetCellValue("Dividends - Tax withheld");
+
+			if (sheetMeta.TryGetValue("DividendTransactionView", out var divMeta) && divMeta.DataRowCount > 0)
+			{
+				WriteSumFormulaCell(taxRow, 1, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Day", czkStyle);
+				WriteSumFormulaCell(taxRow, 2, divMeta.Sheet, divMeta.DataRowCount, "Tax", "per Year", czkStyle);
+			}
+			else
+			{
+				CreateZeroCell(taxRow, 1, czkStyle);
+				CreateZeroCell(taxRow, 2, czkStyle);
+			}
+
+			// Auto-size columns
+			for (int col = 0; col <= 2; col++)
+			{
+				summarySheet.AutoSizeColumn(col);
+			}
+
+			return summarySheet;
+		}
+
+		private static void WriteSumFormulaCell(IRow row, int cellIndex, ISheet sourceSheet, int dataRowCount, string headerPrefix, string headerSuffix, ICellStyle style)
+		{
+			var colIndex = ExcelHelper.FindColumnIndex(sourceSheet, headerPrefix, headerSuffix);
+			var cell = row.CreateCell(cellIndex);
+			cell.CellStyle = style;
+			if (colIndex >= 0)
+			{
+				var colLetter = ExcelHelper.GetExcelColumnLetter(colIndex);
+				var formula = $"SUM({sourceSheet.SheetName}!{colLetter}2:{colLetter}{dataRowCount + 1})";
+				cell.SetCellFormula(formula);
+			}
+			else
+			{
+				cell.SetCellValue(0);
+			}
+		}
+
+		private static void CreateZeroCell(IRow row, int cellIndex, ICellStyle style)
+		{
+			var cell = row.CreateCell(cellIndex);
+			cell.SetCellValue(0);
+			cell.CellStyle = style;
+		}
+	}
+}

--- a/StatementParser/TaxReporterCLI/TaxSummarySheetBuilder.cs
+++ b/StatementParser/TaxReporterCLI/TaxSummarySheetBuilder.cs
@@ -30,6 +30,7 @@ namespace TaxReporterCLI
 				("Deposits - Price", "DepositTransactionView", "Total Price", "per Day", "Total Price", "per Year"),
 			};
 
+			int firstDataRow = 2; // Excel 1-based: row 2 is the first data row
 			int summaryRowIndex = 1;
 			foreach (var (label, sheetName, dailyPrefix, dailySuffix, yearlyPrefix, yearlySuffix) in sections)
 			{
@@ -50,14 +51,15 @@ namespace TaxReporterCLI
 				summaryRowIndex++;
 			}
 
-			// Total row (SUM of the 4 section rows above)
+			// Total row (SUM of all section rows above)
+			int lastDataRow = summaryRowIndex; // Excel 1-based: current summaryRowIndex equals last data Excel row
 			var totalRow = summarySheet.CreateRow(summaryRowIndex);
 			totalRow.CreateCell(0).SetCellValue("Total");
 			var totalDailyCell = totalRow.CreateCell(1);
-			totalDailyCell.SetCellFormula("SUM(B2:B5)");
+			totalDailyCell.SetCellFormula($"SUM(B{firstDataRow}:B{lastDataRow})");
 			totalDailyCell.CellStyle = czkStyle;
 			var totalYearlyCell = totalRow.CreateCell(2);
-			totalYearlyCell.SetCellFormula("SUM(C2:C5)");
+			totalYearlyCell.SetCellFormula($"SUM(C{firstDataRow}:C{lastDataRow})");
 			totalYearlyCell.CellStyle = czkStyle;
 			summaryRowIndex++;
 


### PR DESCRIPTION
## Summary
- Add a **Tax Summary** Excel sheet with `SUM()` formulas referencing existing data sheets, showing both daily-rate and yearly-rate CZK totals side by side for Czech tax reporting
- Sections: Dividends Income, Sales Profit, ESPP Profit, Deposits Price with a Total row; Dividends Tax withheld shown separately below
- Numeric cells formatted with `Kč` currency and auto-width columns
- Add interactive **year filter** that prompts the user when transactions span multiple years, allowing selection of a single year or all combined (runs before exchange rate download)
- Extracted `ExcelHelper` and `TaxSummarySheetBuilder` classes to keep `Output.cs` focused

## Files changed
- `TaxReporterCLI/Output.cs` — collect sheet metadata, delegate summary to new builder
- `TaxReporterCLI/TaxSummarySheetBuilder.cs` — (new) builds the Tax Summary sheet with cross-sheet SUM formulas
- `TaxReporterCLI/ExcelHelper.cs` — (new) reusable Excel utils: column letter conversion, header column scanning
- `TaxReporterCLI/Program.cs` — add year filter before exchange rate download

## Test plan
- [x] Build succeeds with 0 errors
- [x] Generated Excel verified: Tax Summary sheet present with correct cross-sheet SUM formulas
- [x] Currency format `#,##0.00 "Kč"` applied to all numeric cells
- [x] Year filter correctly skips prompt when all transactions are from one year
- [x] Handles piped/redirected stdin gracefully (defaults to all transactions)
- [ ] Manual: open generated Excel in Excel/LibreOffice and verify formulas calculate correctly
- [ ] Manual: test with multi-year input to verify year filter prompt works

🤖 Generated with [Claude Code](https://claude.com/claude-code)