### PR TITLE
Use Fidelity Gain from Purchase for ESPP profit

### DIFF
--- a/StatementParser/StatementParser/Models/ESPPTransaction.cs
+++ b/StatementParser/StatementParser/Models/ESPPTransaction.cs
@@ -13,6 +13,8 @@ namespace StatementParser.Models
 
 		public decimal Amount { get; }
 
+		// Per-share price difference. May not equal TotalProfit / Amount due to
+		// broker-side rounding when GainFromPurchase is provided.
 		public decimal Profit { get; }
 
 		[Description("Total Profit")]
@@ -20,6 +22,15 @@ namespace StatementParser.Models
 
 		public ESPPTransaction(ESPPTransaction eSPPTransaction) : this(eSPPTransaction.Broker, eSPPTransaction.Date, eSPPTransaction.Name, eSPPTransaction.Currency, eSPPTransaction.PurchasePrice, eSPPTransaction.MarketPrice, eSPPTransaction.Amount, eSPPTransaction.TotalProfit)
 		{
+		}
+
+		public ESPPTransaction(Broker broker, DateTime date, string name, Currency currency, decimal purchasePrice, decimal marketPrice, decimal amount) : base(broker, date, name, currency)
+		{
+			this.PurchasePrice = purchasePrice;
+			this.MarketPrice = marketPrice;
+			this.Amount = amount;
+			this.Profit = marketPrice - purchasePrice;
+			this.TotalProfit = Profit * amount;
 		}
 
 		public ESPPTransaction(Broker broker, DateTime date, string name, Currency currency, decimal purchasePrice, decimal marketPrice, decimal amount, decimal gainFromPurchase) : base(broker, date, name, currency)

--- a/StatementParser/StatementParser/Models/ESPPTransaction.cs
+++ b/StatementParser/StatementParser/Models/ESPPTransaction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using StatementParser.Attributes;
 
 namespace StatementParser.Models
@@ -18,17 +18,17 @@ namespace StatementParser.Models
 		[Description("Total Profit")]
 		public decimal TotalProfit { get; }
 
-		public ESPPTransaction(ESPPTransaction eSPPTransaction) : this(eSPPTransaction.Broker, eSPPTransaction.Date, eSPPTransaction.Name, eSPPTransaction.Currency, eSPPTransaction.PurchasePrice, eSPPTransaction.MarketPrice, eSPPTransaction.Amount)
+		public ESPPTransaction(ESPPTransaction eSPPTransaction) : this(eSPPTransaction.Broker, eSPPTransaction.Date, eSPPTransaction.Name, eSPPTransaction.Currency, eSPPTransaction.PurchasePrice, eSPPTransaction.MarketPrice, eSPPTransaction.Amount, eSPPTransaction.TotalProfit)
 		{
 		}
 
-		public ESPPTransaction(Broker broker, DateTime date, string name, Currency currency, decimal purchasePrice, decimal marketPrice, decimal amount) : base(broker, date, name, currency)
+		public ESPPTransaction(Broker broker, DateTime date, string name, Currency currency, decimal purchasePrice, decimal marketPrice, decimal amount, decimal gainFromPurchase) : base(broker, date, name, currency)
 		{
 			this.PurchasePrice = purchasePrice;
 			this.MarketPrice = marketPrice;
 			this.Amount = amount;
 			this.Profit = marketPrice - purchasePrice;
-			this.TotalProfit = Profit * amount;
+			this.TotalProfit = gainFromPurchase;
 		}
 
 		public override string ToString()

--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/FidelityStatementParser.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/FidelityStatementParser.cs
@@ -71,7 +71,7 @@ namespace StatementParser.Parsers.Brokers.Fidelity
         {
             var name = SearchForCompanyName(activityBuyModels, esppRow);
 
-            return new ESPPTransaction(Broker.Fidelity, esppRow.Date, name, Currency.USD, esppRow.PurchasePrice, esppRow.MarketPrice, esppRow.Amount);
+            return new ESPPTransaction(Broker.Fidelity, esppRow.Date, name, Currency.USD, esppRow.PurchasePrice, esppRow.MarketPrice, esppRow.Amount, esppRow.GainFromPurchase);
         }
 
         private DividendTransaction CreateDividendTransaction(ActivityTaxesModel[] activityTaxesModels, ActivityDividendModel activityDividendRow, int year)

--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
@@ -3,7 +3,7 @@ using ASoft.TextDeserializer.Attributes;
 
 namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 {
-	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$?(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$?(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})\\$?(?<GainFromPurchase>[0-9]+\\.[0-9]{2})")]
+	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$?(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$?(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})\\$?(?<GainFromPurchase>[0-9]+\\.[0-9]{2,})")]
 	internal class ESPPModel
 	{
 		public DateTime Date { get; set; }

--- a/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
+++ b/StatementParser/StatementParser/Parsers/Brokers/Fidelity/PdfModels/ESPPModel.cs
@@ -3,12 +3,13 @@ using ASoft.TextDeserializer.Attributes;
 
 namespace StatementParser.Parsers.Brokers.Fidelity.PdfModels
 {
-	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$?(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$?(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})")]
+	[DeserializeByRegex("(?<Date>[0-9]{2}/[0-9]{2}/[0-9]{4})\\$?(?<PurchasePrice>[0-9]+\\.[0-9]{5})\\$?(?<MarketPrice>[0-9]+\\.[0-9]{3})(?<Amount>[0-9]+\\.[0-9]{3})\\$?(?<GainFromPurchase>[0-9]+\\.[0-9]{2})")]
 	internal class ESPPModel
 	{
 		public DateTime Date { get; set; }
 		public decimal PurchasePrice { get; set; }
 		public decimal MarketPrice { get; set; }
 		public decimal Amount { get; set; }
+		public decimal GainFromPurchase { get; set; }
 	}
 }


### PR DESCRIPTION
## Summary
- Extract the "Gain from Purchase" value directly from Fidelity PDF statements (2 decimal places after the Amount field)
- Use this authoritative broker value as `TotalProfit` instead of computing `(MarketPrice - PurchasePrice) * Amount`
- Eliminates ~$0.01-0.05 rounding discrepancy per ESPP entry caused by truncated price precision in the PDF

## Motivation
The Fidelity PDF provides PurchasePrice with 5 decimal places and MarketPrice with 3 decimal places. Computing `(MarketPrice - PurchasePrice) * Amount` from these truncated values produces slightly different results than Fidelity's internal calculation. Using the pre-computed "Gain from Purchase" value is:
1. More accurate — uses Fidelity's full internal precision
2. More defensible for Czech tax reporting (§ 6 odst. 3 zákona o daních z příjmů) — directly traceable to the brokerage statement
3. Consistent with the cz-tax-robot tool which now also uses this value

## Files changed
- `ESPPModel.cs` — Extended regex to capture `GainFromPurchase`
- `ESPPTransaction.cs` — Constructor accepts `gainFromPurchase`, uses it as `TotalProfit`
- `FidelityStatementParser.cs` — Passes `GainFromPurchase` through

## Test plan
- [x] Solution builds with 0 errors
- [x] Verified output with real Fidelity PDFs — TotalProfit values now match PDF exactly (133.63, 139.81, 161.85, 257.23)
- [x] Excel output generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)